### PR TITLE
Take the values ​​defined in rootProject for Gradle file 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,16 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
By November 2, 2020, all apps that are being updated must target at least Android 10 (API level 29).

The project points to API 28, with the safeExtGet function, the project will take the value from the rootProject if it is defined, if it does not take the default. with this your library will not be affected by the new requirement


![image](https://user-images.githubusercontent.com/10731555/97357622-b0acb380-185f-11eb-987a-dc0276a399fc.png)
