### PR TITLE
Fix crash on `start`

### DIFF
--- a/android/src/main/java/com/punarinta/RNSoundLevel/RNSoundLevelModule.java
+++ b/android/src/main/java/com/punarinta/RNSoundLevel/RNSoundLevelModule.java
@@ -142,7 +142,7 @@ class RNSoundLevelModule extends ReactContextBaseJavaModule {
   }
 
   private void logAndRejectPromise(Promise promise, String errorCode, String errorMessage) {
-    Log.e(TAG, errorMessage);
+    Log.e(TAG, "[" + errorCode + "] " + errorMessage);
     promise.reject(errorCode, errorMessage);
   }
 }

--- a/android/src/main/java/com/punarinta/RNSoundLevel/RNSoundLevelModule.java
+++ b/android/src/main/java/com/punarinta/RNSoundLevel/RNSoundLevelModule.java
@@ -63,9 +63,15 @@ class RNSoundLevelModule extends ReactContextBaseJavaModule {
       recorder.prepare();
     } catch (final Exception e) {
       logAndRejectPromise(promise, "COULDNT_PREPARE_RECORDING", e.getMessage());
+      return;
     }
 
-    recorder.start();
+    try {
+      recorder.start();
+    } catch (final Exception e) {
+      logAndRejectPromise(promise, "COULDNT_START_RECORDING", e.getMessage());
+      return;
+    }
 
     frameId = 0;
     isRecording = true;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,17 +1,18 @@
 export type SoundLevelResult = {
   /**
-   * @description Frame number
+   * Frame number
    */
   id: number;
 
   /**
-   * @description Sound level in decibels
-   * @description -160 is a silence
+   * Sound level in decibels
+   *
+   * @note -160 is a silence
    */
   value: number;
 
   /**
-   * @description raw level value, OS-depended
+   * Raw level value, OS-depended
    */
   rawValue: number;
 }
@@ -23,10 +24,32 @@ export type SoundLevelMonitorConfig = {
 
 export type SoundLevelType = {
   /**
-   * @description monitoringInterval is not supported for desktop yet
+   * Start monitoring sound level
+   *
+   * @note `monitoringInterval` is not supported for desktop yet
+   *
+   * @note don't forget to call `stop` eventually
+   *
+   * on Android:
+   * @throws
+   *  - `INVALID_STATE` - sound level recording already started
+   *  - `COULDNT_CONFIGURE_MEDIA_RECORDER` - recording configuration failed (probably due-to lack of android.permission.RECORD_AUDIO)
+   *  - `COULDNT_PREPARE_RECORDING` - preparation fails for some reason
+   *  - `COULDNT_START_RECORDING` - can't start recording session (another app is using recording?)
    */
-  start: (config?: number | SoundLevelMonitorConfig) => void;
-  stop: () => void;
+  start: (config?: number | SoundLevelMonitorConfig) => Promise<void>;
+  /**
+   * Stop monitoring sound level
+   *
+   * on Android:
+   * @throws
+   *  - `INVALID_STATE` - sound level recording hasn't been started
+   *  - `RUNTIME_EXCEPTION` - no valid audio data received. You may be using a device that can't record audio.
+   */
+  stop: () => Promise<void>;
+  /**
+   * User-provided callback to call on each frame
+  */
   onNewFrame: (result: SoundLevelResult) => void;
 }
 

--- a/ios/RNSoundLevelModule.m
+++ b/ios/RNSoundLevelModule.m
@@ -72,7 +72,7 @@ RCT_EXPORT_METHOD(start:(int)monitorInterval samplingRate:(float)sampleRate)
           [NSNumber numberWithInt:AVAudioQualityLow], AVEncoderAudioQualityKey,
           [NSNumber numberWithInt:kAudioFormatMPEG4AAC], AVFormatIDKey,
           [NSNumber numberWithInt:1], AVNumberOfChannelsKey,
-          [NSNumber numberWithFloat:samplingRate], AVSampleRateKey,
+          [NSNumber numberWithFloat:sampleRate], AVSampleRateKey,
           nil];
 
   NSError *error = nil;


### PR DESCRIPTION
PR that implements fix from #34.

Also marks `start` and `stop` as async, to be able to catch promise rejections from js code.

Note: did not check iOS code